### PR TITLE
feat(chatbot): add AI assistant with student context and enrollment

### DIFF
--- a/src/Controller/ChatbotController.php
+++ b/src/Controller/ChatbotController.php
@@ -42,7 +42,7 @@ class ChatbotController extends AbstractController
         $session = $this->requestStack->getSession();
         $history = $session->get(self::SESSION_KEY, []);
 
-        $response = $chatbotService->chat($userMessage, $history, $studentContext);
+        $response = $chatbotService->chat($userMessage, $history, $studentContext, $user);
 
         if ($response['success']) {
             $history[] = ['user' => $userMessage, 'bot' => $response['message']];

--- a/src/Controller/ChatbotController.php
+++ b/src/Controller/ChatbotController.php
@@ -2,7 +2,9 @@
 
 namespace App\Controller;
 
+use App\Repository\EnrollmentRepository;
 use App\Service\GeminiChatbotService;
+use App\Service\TenantContext;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -14,7 +16,11 @@ class ChatbotController extends AbstractController
     private const SESSION_KEY = 'chatbot_history';
     private const MAX_HISTORY = 10;
 
-    public function __construct(private RequestStack $requestStack) {}
+    public function __construct(
+        private RequestStack $requestStack,
+        private TenantContext $tenantContext,
+        private EnrollmentRepository $enrollmentRepository,
+    ) {}
 
     #[Route('/api/chatbot', name: 'api_chatbot', methods: ['POST'])]
     public function chat(Request $request, GeminiChatbotService $chatbotService): JsonResponse
@@ -25,11 +31,18 @@ class ChatbotController extends AbstractController
             return $this->json(['success' => false, 'message' => 'Por favor envía un mensaje válido.'], 400);
         }
 
+        $user = $this->getUser();
+        if ($user === null) {
+            return $this->json(['success' => false, 'message' => 'Debes iniciar sesión para usar el asistente.'], 401);
+        }
+
+        $studentContext = $this->buildStudentContext($user);
+
         $userMessage = trim($data['message']);
         $session = $this->requestStack->getSession();
         $history = $session->get(self::SESSION_KEY, []);
 
-        $response = $chatbotService->chat($userMessage, $history);
+        $response = $chatbotService->chat($userMessage, $history, $studentContext);
 
         if ($response['success']) {
             $history[] = ['user' => $userMessage, 'bot' => $response['message']];
@@ -47,5 +60,35 @@ class ChatbotController extends AbstractController
     {
         $this->requestStack->getSession()->remove(self::SESSION_KEY);
         return $this->json(['success' => true]);
+    }
+
+    private function buildStudentContext(\App\Entity\User $user): array
+    {
+        $interestProfile = $user->getInterestProfile();
+        $interests = $interestProfile?->getInterests() ?? [];
+
+        $enrollments = $this->enrollmentRepository->findBy(['student' => $user]);
+        $enrolledCourses = [];
+        foreach ($enrollments as $enrollment) {
+            $course = $enrollment->getCourse();
+            if ($course !== null) {
+                $enrolledCourses[] = [
+                    'id' => $course->getId(),
+                    'name' => $course->getName(),
+                    'category' => $course->getCategory()?->getName(),
+                ];
+            }
+        }
+
+        $school = $this->tenantContext->getCurrentSchool();
+        $enrollmentOpen = $school === null || $school->isEnrollmentOpen();
+
+        return [
+            'name' => $user->getFullName() ?? 'Estudiante',
+            'grade' => $user->getGrade() ?? 'No especificado',
+            'interests' => $interests,
+            'enrolledCourses' => $enrolledCourses,
+            'enrollmentOpen' => $enrollmentOpen,
+        ];
     }
 }

--- a/src/Repository/CourseRepository.php
+++ b/src/Repository/CourseRepository.php
@@ -22,4 +22,45 @@ class CourseRepository extends TenantAwareRepository
         $qb = $this->createQueryBuilder('c')->where('c.isActive = true');
         return $this->withTenant($qb, 'c')->getQuery()->getResult();
     }
+
+    /**
+     * Returns active courses with available capacity, filtered by student grade and optional category/search.
+     *
+     * @param string|null $grade   Student grade to filter targetGrades (e.g. '3B')
+     * @param string|null $category Category name to filter by
+     * @param string|null $search  Search term for name or description
+     * @return Course[]
+     */
+    public function findAvailableForStudent(
+        ?string $grade = null,
+        ?string $category = null,
+        ?string $search = null,
+    ): array {
+        $qb = $this->createQueryBuilder('c')
+            ->where('c.isActive = true')
+            ->andWhere('c.currentEnrollment < c.maxCapacity');
+
+        // Filter by target grade if provided
+        if ($grade !== null) {
+            $qb->andWhere('JSON_CONTAINS(c.targetGrades, :gradeJson) = 1')
+                ->setParameter('gradeJson', json_encode($grade));
+        }
+
+        // Filter by category name if provided
+        if ($category !== null) {
+            $qb->innerJoin('c.category', 'cat')
+                ->andWhere('cat.name = :category')
+                ->setParameter('category', $category);
+        }
+
+        // Filter by search term on name or description
+        if ($search !== null && $search !== '') {
+            $qb->andWhere('(c.name LIKE :search OR c.description LIKE :search)')
+                ->setParameter('search', '%' . $search . '%');
+        }
+
+        $qb->orderBy('c.name', 'ASC');
+
+        return $this->withTenant($qb, 'c')->getQuery()->getResult();
+    }
 }

--- a/src/Service/EnrollmentService.php
+++ b/src/Service/EnrollmentService.php
@@ -29,6 +29,115 @@ class EnrollmentService
         $this->userRepository = $userRepository;
     }
 
+    /**
+     * Returns available courses with real-time capacity and enrollment status per student.
+     *
+     * @param string|null $category Filter by category name
+     * @param string|null $search   Search term for name or description
+     * @return array{courses: array<int, array{id: int, name: string, category: string|null, teacher: string, schedule: string|null, capacity: string, spots_available: int, enrolled: bool}>, total: int}
+     */
+    public function getAvailableCourses(?string $category = null, ?string $search = null): array
+    {
+        $courses = $this->courseRepository->findAvailableForStudent(
+            grade: null,
+            category: $category,
+            search: $search,
+        );
+
+        $result = [];
+        foreach ($courses as $course) {
+            $spotsAvailable = $course->getMaxCapacity() - $course->getCurrentEnrollment();
+            $teacher = $course->getTeacher();
+            $cat = $course->getCategory();
+
+            $result[] = [
+                'id' => $course->getId(),
+                'name' => $course->getName(),
+                'category' => $cat?->getName(),
+                'teacher' => $teacher ? $teacher->getFullName() : '',
+                'schedule' => $course->getSchedule(),
+                'capacity' => $course->getCurrentEnrollment() . '/' . $course->getMaxCapacity(),
+                'spots_available' => $spotsAvailable,
+            ];
+        }
+
+        return [
+            'courses' => $result,
+            'total' => count($result),
+        ];
+    }
+
+    /**
+     * Returns full details for one course + enrollment status for a specific student.
+     *
+     * @return array{id: int, name: string, description: string|null, category: string|null, teacher: string, schedule: string|null, capacity: string, spots_available: int, enrolled: bool, can_enroll: bool, enrollment_message: string}
+     */
+    public function getCourseDetails(int $courseId, User $student): array
+    {
+        $course = $this->courseRepository->find($courseId);
+
+        if ($course === null) {
+            return [
+                'id' => 0,
+                'name' => '',
+                'description' => null,
+                'category' => null,
+                'teacher' => '',
+                'schedule' => null,
+                'capacity' => '0/0',
+                'spots_available' => 0,
+                'enrolled' => false,
+                'can_enroll' => false,
+                'enrollment_message' => 'Curso no encontrado.',
+            ];
+        }
+
+        $enrolled = $this->isEnrolled($student, $course);
+        $spotsAvailable = $course->getMaxCapacity() - $course->getCurrentEnrollment();
+        $teacher = $course->getTeacher();
+        $cat = $course->getCategory();
+
+        $canEnroll = false;
+        $enrollmentMessage = '';
+
+        if (!$course->isActive()) {
+            $enrollmentMessage = 'El curso no está disponible.';
+        } elseif ($enrolled) {
+            $enrollmentMessage = 'Ya estás inscrito en este curso.';
+        } elseif ($spotsAvailable <= 0) {
+            $enrollmentMessage = 'No hay cupos disponibles.';
+        } else {
+            $canEnroll = true;
+        }
+
+        return [
+            'id' => $course->getId(),
+            'name' => $course->getName(),
+            'description' => $course->getDescription(),
+            'category' => $cat?->getName(),
+            'teacher' => $teacher ? $teacher->getFullName() : '',
+            'schedule' => $course->getSchedule(),
+            'capacity' => $course->getCurrentEnrollment() . '/' . $course->getMaxCapacity(),
+            'spots_available' => $spotsAvailable,
+            'enrolled' => $enrolled,
+            'can_enroll' => $canEnroll,
+            'enrollment_message' => $enrollmentMessage,
+        ];
+    }
+
+    /**
+     * Checks if a student is enrolled in a specific course.
+     */
+    public function isEnrolled(User $student, Course $course): bool
+    {
+        $enrollment = $this->enrollmentRepository->findOneBy([
+            'student' => $student,
+            'course' => $course,
+        ]);
+
+        return $enrollment !== null;
+    }
+
     public function enrollStudent(User $student, Course $course): array // Devuelve un array con resultado y mensaje
     {
         // Verificar que el usuario sea un estudiante (opcional, pero buena práctica aquí o en el controlador)

--- a/src/Service/GeminiChatbotService.php
+++ b/src/Service/GeminiChatbotService.php
@@ -2,32 +2,99 @@
 
 namespace App\Service;
 
+use App\Entity\User;
 use App\Repository\CourseRepository;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
 class GeminiChatbotService
 {
     private const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent';
-    
+    private const MAX_TOOL_ITERATIONS = 3;
+
+    /** @var array<int, array{name: string, description: string, parameters: array}> */
+    private const TOOL_DECLARATIONS = [
+        [
+            'name' => 'get_available_courses',
+            'description' => 'Lista los cursos electivos disponibles. Usa esta función cuando el estudiante quiera ver cursos, buscar por categoría, o ver opciones.',
+            'parameters' => [
+                'type' => 'OBJECT',
+                'properties' => [
+                    'category' => [
+                        'type' => 'STRING',
+                        'description' => "Filtrar por área (ej: 'Filosofía', 'Artes', 'Ciencias'). Opcional.",
+                    ],
+                    'search' => [
+                        'type' => 'STRING',
+                        'description' => 'Buscar por nombre o descripción. Opcional.',
+                    ],
+                ],
+            ],
+        ],
+        [
+            'name' => 'get_course_details',
+            'description' => 'Muestra detalles completos de un curso específico: descripción, profesor, horario, cupos, y si el estudiante ya está inscrito.',
+            'parameters' => [
+                'type' => 'OBJECT',
+                'properties' => [
+                    'course_id' => [
+                        'type' => 'INTEGER',
+                        'description' => 'ID numérico del curso',
+                    ],
+                ],
+                'required' => ['course_id'],
+            ],
+        ],
+        [
+            'name' => 'enroll_in_course',
+            'description' => "Muestra los detalles de inscripción de un curso y verifica si el estudiante puede inscribirse. NO inscribe directamente — solo muestra información para que el estudiante confirme.",
+            'parameters' => [
+                'type' => 'OBJECT',
+                'properties' => [
+                    'course_id' => [
+                        'type' => 'INTEGER',
+                        'description' => 'ID numérico del curso a inscribir',
+                    ],
+                ],
+                'required' => ['course_id'],
+            ],
+        ],
+        [
+            'name' => 'confirm_enrollment',
+            'description' => "Confirma la inscripción del estudiante en un curso DESPUÉS de que el estudiante dio confirmación explícita (dijo 'sí', 'quiero', 'dale', etc.).",
+            'parameters' => [
+                'type' => 'OBJECT',
+                'properties' => [
+                    'course_id' => [
+                        'type' => 'INTEGER',
+                        'description' => 'ID numérico del curso a confirmar inscripción',
+                    ],
+                ],
+                'required' => ['course_id'],
+            ],
+        ],
+    ];
+
+    private ?User $currentUser = null;
+
     public function __construct(
         private HttpClientInterface $httpClient,
         private CourseRepository $courseRepository,
+        private EnrollmentService $enrollmentService,
         private LoggerInterface $logger,
         private string $geminiApiKey
     ) {
     }
 
-    public function chat(string $userMessage, array $history = [], array $studentContext = []): array
+    public function chat(string $userMessage, array $history = [], array $studentContext = [], ?User $user = null): array
     {
         try {
-            // Obtener información de los cursos disponibles
-            $coursesContext = $this->buildCoursesContext();
+            $this->currentUser = $user;
 
-            // Construir el prompt con contexto
+            $coursesContext = $this->buildCoursesContext();
             $systemPrompt = $this->buildSystemPrompt($coursesContext, $studentContext);
 
-            // Construir el array de contenidos incluyendo historial
             $contents = [['parts' => [['text' => $systemPrompt]]]];
             foreach ($history as $turn) {
                 $contents[] = ['role' => 'user', 'parts' => [['text' => $turn['user']]]];
@@ -35,50 +102,86 @@ class GeminiChatbotService
             }
             $contents[] = ['role' => 'user', 'parts' => [['text' => $userMessage]]];
 
-            // Llamar a la API de Gemini
-            $response = $this->httpClient->request('POST', self::GEMINI_API_URL, [
-                'query' => ['key' => $this->geminiApiKey],
-                'json' => [
-                    'contents' => $contents,
-                    'generationConfig' => [
-                        'temperature' => 0.7,
-                        'topK' => 40,
-                        'topP' => 0.95,
-                        'maxOutputTokens' => 1024,
-                    ]
-                ]
-            ]);
+            $lastTextResponse = null;
 
-            $data = $response->toArray();
-            
-            if (isset($data['candidates'][0]['content']['parts'][0]['text'])) {
-                $botResponse = $data['candidates'][0]['content']['parts'][0]['text'];
-                
-                return [
-                    'success' => true,
-                    'message' => $botResponse
+            for ($iteration = 0; $iteration < self::MAX_TOOL_ITERATIONS; $iteration++) {
+                $response = $this->callGeminiApi($contents);
+                $data = $response->toArray();
+
+                $parts = $data['candidates'][0]['content']['parts'] ?? [];
+
+                // Extract text response if present
+                foreach ($parts as $part) {
+                    if (isset($part['text'])) {
+                        $lastTextResponse = $part['text'];
+                    }
+                }
+
+                // Check for function call
+                $functionCall = null;
+                foreach ($parts as $part) {
+                    if (isset($part['functionCall'])) {
+                        $functionCall = $part['functionCall'];
+                        break;
+                    }
+                }
+
+                if ($functionCall === null) {
+                    // No function call — return text response
+                    if ($lastTextResponse !== null) {
+                        return ['success' => true, 'message' => $lastTextResponse];
+                    }
+
+                    return [
+                        'success' => false,
+                        'message' => 'Lo siento, no pude procesar tu mensaje. ¿Podrías reformularlo?',
+                    ];
+                }
+
+                // Execute the tool
+                $toolName = $functionCall['name'];
+                $toolArgs = $functionCall['args'] ?? [];
+                $toolResult = $this->executeTool($toolName, $toolArgs);
+
+                // Append function call + response to contents
+                $contents[] = [
+                    'role' => 'model',
+                    'parts' => [['functionCall' => $functionCall]],
+                ];
+                $contents[] = [
+                    'role' => 'user',
+                    'parts' => [[
+                        'functionResponse' => [
+                            'name' => $toolName,
+                            'response' => $toolResult,
+                        ],
+                    ]],
                 ];
             }
 
+            // Loop cap reached
+            $this->logger->warning(
+                'Gemini chatbot tool_call loop reached max iterations (' . self::MAX_TOOL_ITERATIONS . ')'
+            );
+
             return [
-                'success' => false,
-                'message' => 'Lo siento, no pude procesar tu mensaje. ¿Podrías reformularlo?'
+                'success' => true,
+                'message' => $lastTextResponse ?? 'Lo siento, no pude completar tu solicitud.',
             ];
 
         } catch (\Exception $e) {
             $this->logger->error('Error en Gemini chatbot: ' . $e->getMessage());
-            
-            // Detectar error de límite de cuota (429)
+
             if (str_contains($e->getMessage(), '429') || str_contains($e->getMessage(), 'RESOURCE_EXHAUSTED')) {
                 return [
                     'success' => false,
-                    'message' => 'El asistente IA está temporalmente ocupado. Por favor intenta de nuevo en unos segundos. 😊'
+                    'message' => 'El asistente IA está temporalmente ocupado. Por favor intenta de nuevo en unos segundos. 😊',
                 ];
             }
-            
+
             return [
                 'success' => false,
-                'message' => 'Lo siento, estoy teniendo problemas técnicos. Por favor intenta más tarde.'
+                'message' => 'Lo siento, estoy teniendo problemas técnicos. Por favor intenta más tarde.',
             ];
         }
     }
@@ -104,6 +207,117 @@ class GeminiChatbotService
         return $context;
     }
 
+    private function callGeminiApi(array $contents): ResponseInterface
+    {
+        return $this->httpClient->request('POST', self::GEMINI_API_URL, [
+            'query' => ['key' => $this->geminiApiKey],
+            'json' => [
+                'contents' => $contents,
+                'tools' => self::TOOL_DECLARATIONS,
+                'toolConfig' => [
+                    'functionCallingConfig' => [
+                        'mode' => 'AUTO',
+                    ],
+                ],
+                'generationConfig' => [
+                    'temperature' => 0.7,
+                    'topK' => 40,
+                    'topP' => 0.95,
+                    'maxOutputTokens' => 1024,
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Execute a tool call and return the result as an array.
+     */
+    private function executeTool(string $toolName, array $args): array
+    {
+        try {
+            switch ($toolName) {
+                case 'get_available_courses':
+                    return $this->enrollmentService->getAvailableCourses(
+                        category: $args['category'] ?? null,
+                        search: $args['search'] ?? null,
+                    );
+
+                case 'get_course_details':
+                    $courseId = $args['course_id'] ?? 0;
+                    if ($this->currentUser === null) {
+                        return ['error' => 'Se requiere autenticación para ver detalles del curso.'];
+                    }
+                    return $this->enrollmentService->getCourseDetails(
+                        courseId: (int) $courseId,
+                        student: $this->currentUser,
+                    );
+
+                case 'enroll_in_course':
+                    $courseId = $args['course_id'] ?? 0;
+                    if ($this->currentUser === null) {
+                        return ['error' => 'Se requiere autenticación para inscribirse.'];
+                    }
+                    // Preview only — get course details, do NOT enroll
+                    $details = $this->enrollmentService->getCourseDetails(
+                        courseId: (int) $courseId,
+                        student: $this->currentUser,
+                    );
+
+                    if ($details['id'] === 0) {
+                        return [
+                            'course_id' => (int) $courseId,
+                            'course_name' => '',
+                            'spots_available' => 0,
+                            'enrolled' => false,
+                            'can_enroll' => false,
+                            'message' => 'Curso no encontrado.',
+                        ];
+                    }
+
+                    return [
+                        'course_id' => $details['id'],
+                        'course_name' => $details['name'],
+                        'spots_available' => $details['spots_available'],
+                        'enrolled' => $details['enrolled'],
+                        'can_enroll' => $details['can_enroll'],
+                        'message' => $details['enrollment_message']
+                            ?: "Hay {$details['spots_available']} cupos disponibles. ¿Te inscribís?",
+                    ];
+
+                case 'confirm_enrollment':
+                    $courseId = $args['course_id'] ?? 0;
+                    if ($this->currentUser === null) {
+                        return ['success' => false, 'message' => 'Se requiere autenticación para inscribirse.'];
+                    }
+
+                    $course = $this->courseRepository->find((int) $courseId);
+                    if ($course === null) {
+                        return ['success' => false, 'message' => 'Curso no encontrado.'];
+                    }
+
+                    $result = $this->enrollmentService->enrollStudent($this->currentUser, $course);
+
+                    if ($result['success']) {
+                        return [
+                            'success' => true,
+                            'message' => "¡Te inscribiste exitosamente en {$course->getName()}!",
+                        ];
+                    }
+
+                    return [
+                        'success' => false,
+                        'message' => $result['message'],
+                    ];
+
+                default:
+                    return ['error' => "Herramienta no reconocida: {$toolName}"];
+            }
+        } catch (\Exception $e) {
+            $this->logger->error("Error ejecutando tool '{$toolName}': " . $e->getMessage());
+            return ['error' => 'Error al procesar la solicitud. Por favor intenta de nuevo.'];
+        }
+    }
+
     private function buildSystemPrompt(string $coursesContext, array $studentContext = []): string
     {
         $studentBlock = $this->buildStudentContextBlock($studentContext);
@@ -115,12 +329,16 @@ INFORMACIÓN DE CURSOS DISPONIBLES:
 {$coursesContext}
 INSTRUCCIONES:
 - Sé amigable, cercano y motivador. Usa lenguaje apropiado para estudiantes de enseñanza media.
-- Recomienda cursos basándote en los intereses del estudiante.
-- Si te preguntan por un curso específico, busca en la lista y proporciona detalles.
-- Si no sabes algo, sé honesto y sugiere contactar a un profesor o administrador.
+- Cuando el estudiante quiera ver cursos, usa get_available_courses.
+- Para detalles de un curso específico, usa get_course_details.
+- Para inscribir a un estudiante:
+  a. Primero usa enroll_in_course para mostrar detalles y cupos.
+  b. Pregunta "¿Te inscribís?" al estudiante.
+  c. SOLO cuando el estudiante confirme explícitamente ("sí", "quiero", "dale"), usa confirm_enrollment.
+- NUNCA inscribas sin confirmación explícita del estudiante.
+- Si el estudiante pregunta por temas no relacionados con cursos, profesores, horarios o inscripciones, responde amablemente: "¡Ups! Solo puedo ayudarte con temas de cursos electivos, profesores, horarios e inscripciones. ¿Quieres que te ayude a encontrar un curso?" No intentes responder preguntas fuera de este alcance.
 - Mantén las respuestas concisas pero informativas (máximo 3-4 párrafos).
 - Usa emojis ocasionalmente para ser más amigable 😊
-- Si te preguntan por temas no relacionados con cursos, profesores, horarios o inscripciones, responde amablemente: "¡Ups! Solo puedo ayudarte con temas de cursos electivos, profesores, horarios e inscripciones. ¿Quieres que te ayude a encontrar un curso?" No intentes responder preguntas fuera de este alcance.
 
 PROMPT;
     }

--- a/src/Service/GeminiChatbotService.php
+++ b/src/Service/GeminiChatbotService.php
@@ -18,14 +18,14 @@ class GeminiChatbotService
     ) {
     }
 
-    public function chat(string $userMessage, array $history = []): array
+    public function chat(string $userMessage, array $history = [], array $studentContext = []): array
     {
         try {
             // Obtener información de los cursos disponibles
             $coursesContext = $this->buildCoursesContext();
 
             // Construir el prompt con contexto
-            $systemPrompt = $this->buildSystemPrompt($coursesContext);
+            $systemPrompt = $this->buildSystemPrompt($coursesContext, $studentContext);
 
             // Construir el array de contenidos incluyendo historial
             $contents = [['parts' => [['text' => $systemPrompt]]]];
@@ -104,29 +104,68 @@ class GeminiChatbotService
         return $context;
     }
 
-    private function buildSystemPrompt(string $coursesContext): string
+    private function buildSystemPrompt(string $coursesContext, array $studentContext = []): string
     {
+        $studentBlock = $this->buildStudentContextBlock($studentContext);
+
         return <<<PROMPT
-Eres un asistente virtual amigable y útil del sistema de cursos electivos de un colegio chileno.
-
-Tu objetivo es ayudar a los estudiantes a:
-1. Descubrir cursos que les puedan interesar
-2. Responder preguntas sobre los cursos disponibles
-3. Recomendar cursos según sus intereses
-4. Proporcionar información sobre profesores, horarios y cupos
-
+Eres ElectivoBot, el asistente virtual del sistema de cursos electivos de un colegio chileno.
+{$studentBlock}
 INFORMACIÓN DE CURSOS DISPONIBLES:
 {$coursesContext}
-
 INSTRUCCIONES:
-- Sé amigable, cercano y motivador
-- Usa lenguaje apropiado para estudiantes de enseñanza media
-- Si te preguntan por un curso específico, busca en la lista y proporciona detalles
-- Si te piden recomendaciones, pregunta por sus intereses primero
-- Si no sabes algo, sé honesto y sugiere contactar a un profesor o administrador
-- Mantén las respuestas concisas pero informativas (máximo 3-4 párrafos)
+- Sé amigable, cercano y motivador. Usa lenguaje apropiado para estudiantes de enseñanza media.
+- Recomienda cursos basándote en los intereses del estudiante.
+- Si te preguntan por un curso específico, busca en la lista y proporciona detalles.
+- Si no sabes algo, sé honesto y sugiere contactar a un profesor o administrador.
+- Mantén las respuestas concisas pero informativas (máximo 3-4 párrafos).
 - Usa emojis ocasionalmente para ser más amigable 😊
+- Si te preguntan por temas no relacionados con cursos, profesores, horarios o inscripciones, responde amablemente: "¡Ups! Solo puedo ayudarte con temas de cursos electivos, profesores, horarios e inscripciones. ¿Quieres que te ayude a encontrar un curso?" No intentes responder preguntas fuera de este alcance.
 
 PROMPT;
+    }
+
+    private function buildStudentContextBlock(array $studentContext): string
+    {
+        if (empty($studentContext)) {
+            return '';
+        }
+
+        $lines = [];
+        $lines[] = 'CONTEXTO DEL ESTUDIANTE:';
+        $lines[] = '- Nombre: ' . ($studentContext['name'] ?? 'Estudiante');
+        $lines[] = '- Curso: ' . ($studentContext['grade'] ?? 'No especificado');
+
+        // Interests: array like ['Filosofía' => 4, 'Artes' => 5]
+        $interests = $studentContext['interests'] ?? [];
+        if (!empty($interests)) {
+            $interestParts = [];
+            foreach ($interests as $topic => $score) {
+                $interestParts[] = "{$topic} (nivel {$score})";
+            }
+            $lines[] = '- Intereses: ' . implode(', ', $interestParts);
+        } else {
+            $lines[] = '- Intereses: Sin intereses registrados aún';
+        }
+
+        // Enrolled courses
+        $enrolledCourses = $studentContext['enrolledCourses'] ?? [];
+        if (!empty($enrolledCourses)) {
+            $courseNames = array_map(fn($c) => $c['name'] ?? $c, $enrolledCourses);
+            $lines[] = '- Cursos inscrito actualmente: ' . implode(', ', $courseNames);
+        } else {
+            $lines[] = '- Cursos inscrito actualmente: Ninguno';
+        }
+
+        // Enrollment period status
+        $enrollmentOpen = $studentContext['enrollmentOpen'] ?? null;
+        if ($enrollmentOpen === true) {
+            $lines[] = '- Período de inscripción: Abierto';
+        } elseif ($enrollmentOpen === false) {
+            $lines[] = '- Período de inscripción: Cerrado';
+        }
+
+        $lines[] = '';
+        return implode("\n", $lines);
     }
 }

--- a/tests/Unit/Service/EnrollmentServiceTest.php
+++ b/tests/Unit/Service/EnrollmentServiceTest.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\Course;
+use App\Entity\CourseCategory;
+use App\Entity\Enrollment;
+use App\Entity\User;
+use App\Repository\CourseRepository;
+use App\Repository\EnrollmentRepository;
+use App\Repository\UserRepository;
+use App\Service\EnrollmentService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class EnrollmentServiceTest extends TestCase
+{
+    private EnrollmentService $service;
+    private \PHPUnit\Framework\MockObject\MockObject $entityManager;
+    private \PHPUnit\Framework\MockObject\MockObject $courseRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $enrollmentRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $userRepository;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->courseRepository = $this->createMock(CourseRepository::class);
+        $this->enrollmentRepository = $this->createMock(EnrollmentRepository::class);
+        $this->userRepository = $this->createMock(UserRepository::class);
+
+        $this->service = new EnrollmentService(
+            $this->entityManager,
+            $this->courseRepository,
+            $this->enrollmentRepository,
+            $this->userRepository,
+        );
+    }
+
+    private function createStudent(int $id = 1, string $grade = '3B'): User
+    {
+        $student = $this->createMock(User::class);
+        $student->method('getId')->willReturn($id);
+        $student->method('getGrade')->willReturn($grade);
+        $student->method('getFullName')->willReturn("Student $id");
+        return $student;
+    }
+
+    private function createCourse(
+        int $id = 1,
+        string $name = 'Filosofía Moderna',
+        int $maxCapacity = 25,
+        int $currentEnrollment = 18,
+        bool $isActive = true,
+        ?string $schedule = 'Lunes 10:00-11:30',
+        ?string $categoryName = 'Filosofía',
+        ?User $teacher = null,
+    ): Course {
+        $course = $this->createMock(Course::class);
+        $course->method('getId')->willReturn($id);
+        $course->method('getName')->willReturn($name);
+        $course->method('getDescription')->willReturn('Exploración de corrientes filosóficas');
+        $course->method('getMaxCapacity')->willReturn($maxCapacity);
+        $course->method('getCurrentEnrollment')->willReturn($currentEnrollment);
+        $course->method('isActive')->willReturn($isActive);
+        $course->method('getSchedule')->willReturn($schedule);
+        $course->method('getTeacher')->willReturn($teacher);
+
+        $category = null;
+        if ($categoryName !== null) {
+            $category = $this->createMock(CourseCategory::class);
+            $category->method('getName')->willReturn($categoryName);
+        }
+        $course->method('getCategory')->willReturn($category);
+
+        return $course;
+    }
+
+    // --- getAvailableCourses tests ---
+
+    public function testGetAvailableCoursesReturnsCoursesWithCapacity(): void
+    {
+        $course1 = $this->createCourse(id: 1, name: 'Filosofía Moderna', maxCapacity: 25, currentEnrollment: 18);
+        $course2 = $this->createCourse(id: 2, name: 'Artes Visuales', maxCapacity: 20, currentEnrollment: 20);
+
+        $this->courseRepository
+            ->method('findAvailableForStudent')
+            ->with(grade: null, category: null, search: null)
+            ->willReturn([$course1]);
+
+        $result = $this->service->getAvailableCourses();
+
+        $this->assertCount(1, $result['courses']);
+        $this->assertEquals(1, $result['total']);
+
+        $course = $result['courses'][0];
+        $this->assertEquals(1, $course['id']);
+        $this->assertEquals('Filosofía Moderna', $course['name']);
+        $this->assertEquals('Filosofía', $course['category']);
+        $this->assertEquals('18/25', $course['capacity']);
+        $this->assertEquals(7, $course['spots_available']);
+    }
+
+    public function testGetAvailableCoursesWithCategoryFilter(): void
+    {
+        $this->courseRepository
+            ->expects($this->once())
+            ->method('findAvailableForStudent')
+            ->with(grade: null, category: 'Artes', search: null)
+            ->willReturn([]);
+
+        $result = $this->service->getAvailableCourses(category: 'Artes');
+
+        $this->assertCount(0, $result['courses']);
+        $this->assertEquals(0, $result['total']);
+    }
+
+    public function testGetAvailableCoursesWithSearchFilter(): void
+    {
+        $this->courseRepository
+            ->expects($this->once())
+            ->method('findAvailableForStudent')
+            ->with(grade: null, category: null, search: 'filosofía')
+            ->willReturn([]);
+
+        $result = $this->service->getAvailableCourses(search: 'filosofía');
+
+        $this->assertCount(0, $result['courses']);
+        $this->assertEquals(0, $result['total']);
+    }
+
+    public function testGetAvailableCoursesReturnsEmptyWhenNoCourses(): void
+    {
+        $this->courseRepository
+            ->method('findAvailableForStudent')
+            ->willReturn([]);
+
+        $result = $this->service->getAvailableCourses();
+
+        $this->assertCount(0, $result['courses']);
+        $this->assertEquals(0, $result['total']);
+    }
+
+    public function testGetAvailableCoursesHandlesNullTeacherAndCategory(): void
+    {
+        $course = $this->createCourse(
+            id: 1,
+            name: 'Curso Sin Profesor',
+            teacher: null,
+            categoryName: null,
+        );
+
+        $this->courseRepository
+            ->method('findAvailableForStudent')
+            ->willReturn([$course]);
+
+        $result = $this->service->getAvailableCourses();
+
+        $this->assertEquals('', $result['courses'][0]['teacher']);
+        $this->assertNull($result['courses'][0]['category']);
+    }
+
+    // --- getCourseDetails tests ---
+
+    public function testGetCourseDetailsReturnsFullDetails(): void
+    {
+        $student = $this->createStudent();
+        $teacher = $this->createMock(User::class);
+        $teacher->method('getFullName')->willReturn('Prof. García');
+        $course = $this->createCourse(id: 1, teacher: $teacher);
+
+        $this->courseRepository
+            ->method('find')
+            ->with(1)
+            ->willReturn($course);
+
+        $this->enrollmentRepository
+            ->method('findOneBy')
+            ->with(['student' => $student, 'course' => $course])
+            ->willReturn(null);
+
+        $result = $this->service->getCourseDetails(1, $student);
+
+        $this->assertEquals(1, $result['id']);
+        $this->assertEquals('Filosofía Moderna', $result['name']);
+        $this->assertEquals('Exploración de corrientes filosóficas', $result['description']);
+        $this->assertEquals('Filosofía', $result['category']);
+        $this->assertEquals('Prof. García', $result['teacher']);
+        $this->assertEquals('18/25', $result['capacity']);
+        $this->assertEquals(7, $result['spots_available']);
+        $this->assertFalse($result['enrolled']);
+        $this->assertTrue($result['can_enroll']);
+        $this->assertEquals('', $result['enrollment_message']);
+    }
+
+    public function testGetCourseDetailsReturnsNotFound(): void
+    {
+        $student = $this->createStudent();
+
+        $this->courseRepository
+            ->method('find')
+            ->with(999)
+            ->willReturn(null);
+
+        $result = $this->service->getCourseDetails(999, $student);
+
+        $this->assertEquals(0, $result['id']);
+        $this->assertEquals('', $result['name']);
+        $this->assertFalse($result['can_enroll']);
+        $this->assertEquals('Curso no encontrado.', $result['enrollment_message']);
+    }
+
+    public function testGetCourseDetailsWhenStudentIsEnrolled(): void
+    {
+        $student = $this->createStudent();
+        $course = $this->createCourse(id: 1);
+        $enrollment = new Enrollment();
+
+        $this->courseRepository
+            ->method('find')
+            ->with(1)
+            ->willReturn($course);
+
+        $this->enrollmentRepository
+            ->method('findOneBy')
+            ->with(['student' => $student, 'course' => $course])
+            ->willReturn($enrollment);
+
+        $result = $this->service->getCourseDetails(1, $student);
+
+        $this->assertTrue($result['enrolled']);
+        $this->assertFalse($result['can_enroll']);
+        $this->assertEquals('Ya estás inscrito en este curso.', $result['enrollment_message']);
+    }
+
+    public function testGetCourseDetailsWhenCourseIsInactive(): void
+    {
+        $student = $this->createStudent();
+        $course = $this->createCourse(id: 1, isActive: false);
+
+        $this->courseRepository
+            ->method('find')
+            ->with(1)
+            ->willReturn($course);
+
+        $this->enrollmentRepository
+            ->method('findOneBy')
+            ->willReturn(null);
+
+        $result = $this->service->getCourseDetails(1, $student);
+
+        $this->assertFalse($result['can_enroll']);
+        $this->assertEquals('El curso no está disponible.', $result['enrollment_message']);
+    }
+
+    public function testGetCourseDetailsWhenNoSpotsAvailable(): void
+    {
+        $student = $this->createStudent();
+        $course = $this->createCourse(id: 1, maxCapacity: 25, currentEnrollment: 25);
+
+        $this->courseRepository
+            ->method('find')
+            ->with(1)
+            ->willReturn($course);
+
+        $this->enrollmentRepository
+            ->method('findOneBy')
+            ->willReturn(null);
+
+        $result = $this->service->getCourseDetails(1, $student);
+
+        $this->assertEquals(0, $result['spots_available']);
+        $this->assertFalse($result['can_enroll']);
+        $this->assertEquals('No hay cupos disponibles.', $result['enrollment_message']);
+    }
+
+    // --- isEnrolled tests ---
+
+    public function testIsEnrolledReturnsTrueWhenEnrolled(): void
+    {
+        $student = $this->createStudent();
+        $course = $this->createCourse();
+        $enrollment = new Enrollment();
+
+        $this->enrollmentRepository
+            ->method('findOneBy')
+            ->with(['student' => $student, 'course' => $course])
+            ->willReturn($enrollment);
+
+        $this->assertTrue($this->service->isEnrolled($student, $course));
+    }
+
+    public function testIsEnrolledReturnsFalseWhenNotEnrolled(): void
+    {
+        $student = $this->createStudent();
+        $course = $this->createCourse();
+
+        $this->enrollmentRepository
+            ->method('findOneBy')
+            ->with(['student' => $student, 'course' => $course])
+            ->willReturn(null);
+
+        $this->assertFalse($this->service->isEnrolled($student, $course));
+    }
+}

--- a/tests/Unit/Service/GeminiChatbotServiceTest.php
+++ b/tests/Unit/Service/GeminiChatbotServiceTest.php
@@ -1,0 +1,509 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\Course;
+use App\Entity\CourseCategory;
+use App\Entity\User;
+use App\Repository\CourseRepository;
+use App\Service\GeminiChatbotService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class GeminiChatbotServiceTest extends TestCase
+{
+    private GeminiChatbotService $service;
+    private \PHPUnit\Framework\MockObject\MockObject $httpClient;
+    private \PHPUnit\Framework\MockObject\MockObject $courseRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $logger;
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createMock(HttpClientInterface::class);
+        $this->courseRepository = $this->createMock(CourseRepository::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->service = new GeminiChatbotService(
+            $this->httpClient,
+            $this->courseRepository,
+            $this->logger,
+            'test-api-key',
+        );
+    }
+
+    private function createCourse(
+        int $id = 1,
+        string $name = 'Filosofía Moderna',
+        ?string $categoryName = 'Filosofía',
+        ?string $teacherName = 'Prof. García',
+        ?string $schedule = 'Lunes 10:00-11:30',
+        int $maxCapacity = 25,
+        int $currentEnrollment = 18,
+    ): Course {
+        $course = $this->createMock(Course::class);
+        $course->method('getName')->willReturn($name);
+        $course->method('getDescription')->willReturn('Exploración de corrientes filosóficas');
+        $course->method('getMaxCapacity')->willReturn($maxCapacity);
+        $course->method('getCurrentEnrollment')->willReturn($currentEnrollment);
+        $course->method('getSchedule')->willReturn($schedule);
+
+        $category = null;
+        if ($categoryName !== null) {
+            $category = $this->createMock(CourseCategory::class);
+            $category->method('getName')->willReturn($categoryName);
+        }
+        $course->method('getCategory')->willReturn($category);
+
+        $teacher = null;
+        if ($teacherName !== null) {
+            $teacher = $this->createMock(User::class);
+            $teacher->method('getFullName')->willReturn($teacherName);
+        }
+        $course->method('getTeacher')->willReturn($teacher);
+
+        return $course;
+    }
+
+    private function mockSuccessfulGeminiResponse(string $text = '¡Hola! ¿En qué te puedo ayudar?'): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [
+                            ['text' => $text],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->httpClient
+            ->method('request')
+            ->willReturn($response);
+    }
+
+    private function mockGeminiWithCapturedContents(): array
+    {
+        $capturedContents = [];
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [
+                            ['text' => 'Respuesta del bot'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function ($method, $url, $options) use (&$capturedContents) {
+                $capturedContents = $options['json']['contents'] ?? [];
+                return $this->createMock(ResponseInterface::class);
+            });
+
+        // We need to re-mock to also return the toArray properly
+        $this->httpClient = $this->createMock(HttpClientInterface::class);
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function ($method, $url, $options) use (&$capturedContents) {
+                $capturedContents = $options['json']['contents'] ?? [];
+                $response = $this->createMock(ResponseInterface::class);
+                $response->method('toArray')->willReturn([
+                    'candidates' => [
+                        [
+                            'content' => [
+                                'parts' => [
+                                    ['text' => 'Respuesta del bot'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]);
+                return $response;
+            });
+
+        $this->service = new GeminiChatbotService(
+            $this->httpClient,
+            $this->courseRepository,
+            $this->logger,
+            'test-api-key',
+        );
+
+        return $capturedContents;
+    }
+
+    // --- Basic chat tests ---
+
+    public function testChatReturnsSuccessResponse(): void
+    {
+        $this->courseRepository
+            ->method('findActiveForContext')
+            ->willReturn([$this->createCourse()]);
+
+        $this->mockSuccessfulGeminiResponse('¡Hola! ¿Cómo estás?');
+
+        $result = $this->service->chat('Hola');
+
+        $this->assertTrue($result['success']);
+        $this->assertEquals('¡Hola! ¿Cómo estás?', $result['message']);
+    }
+
+    public function testChatReturnsErrorWhenNoTextInResponse(): void
+    {
+        $this->courseRepository
+            ->method('findActiveForContext')
+            ->willReturn([]);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn(['candidates' => []]);
+
+        $this->httpClient->method('request')->willReturn($response);
+
+        $result = $this->service->chat('Hola');
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('reformularlo', $result['message']);
+    }
+
+    public function testChatHandlesRateLimitError(): void
+    {
+        $this->courseRepository
+            ->method('findActiveForContext')
+            ->willReturn([]);
+
+        $this->httpClient
+            ->method('request')
+            ->willThrowException(new \RuntimeException('429 Too Many Requests'));
+
+        $result = $this->service->chat('Hola');
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('ocupado', $result['message']);
+    }
+
+    public function testChatHandlesGenericException(): void
+    {
+        $this->courseRepository
+            ->method('findActiveForContext')
+            ->willReturn([]);
+
+        $this->httpClient
+            ->method('request')
+            ->willThrowException(new \RuntimeException('Connection failed'));
+
+        $result = $this->service->chat('Hola');
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('problemas técnicos', $result['message']);
+    }
+
+    // --- Student context tests ---
+
+    public function testChatWithStudentContextIncludesNameInPrompt(): void
+    {
+        $this->courseRepository
+            ->method('findActiveForContext')
+            ->willReturn([]);
+
+        $capturedContents = [];
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [['text' => 'Hola Juan!']],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function ($method, $url, $options) use (&$capturedContents) {
+                $capturedContents = $options['json']['contents'] ?? [];
+                $response = $this->createMock(ResponseInterface::class);
+                $response->method('toArray')->willReturn([
+                    'candidates' => [
+                        [
+                            'content' => [
+                                'parts' => [['text' => 'Hola Juan!']],
+                            ],
+                        ],
+                    ],
+                ]);
+                return $response;
+            });
+
+        $studentContext = [
+            'name' => 'Juan Pérez',
+            'grade' => '3B',
+            'interests' => ['Filosofía' => 4, 'Artes' => 5],
+            'enrolledCourses' => [
+                ['id' => 1, 'name' => 'Filosofía Moderna', 'category' => 'Filosofía'],
+            ],
+            'enrollmentOpen' => true,
+        ];
+
+        $result = $this->service->chat('¿Qué cursos me recomiendas?', [], $studentContext);
+
+        $this->assertTrue($result['success']);
+
+        // Verify the system prompt (first message) contains student context
+        $systemPrompt = $capturedContents[0]['parts'][0]['text'];
+        $this->assertStringContainsString('Juan Pérez', $systemPrompt);
+        $this->assertStringContainsString('3B', $systemPrompt);
+        $this->assertStringContainsString('Filosofía (nivel 4)', $systemPrompt);
+        $this->assertStringContainsString('Artes (nivel 5)', $systemPrompt);
+        $this->assertStringContainsString('Filosofía Moderna', $systemPrompt);
+        $this->assertStringContainsString('Abierto', $systemPrompt);
+    }
+
+    public function testChatWithoutStudentContextOmitsStudentBlock(): void
+    {
+        $this->courseRepository
+            ->method('findActiveForContext')
+            ->willReturn([]);
+
+        $capturedContents = [];
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function ($method, $url, $options) use (&$capturedContents) {
+                $capturedContents = $options['json']['contents'] ?? [];
+                $response = $this->createMock(ResponseInterface::class);
+                $response->method('toArray')->willReturn([
+                    'candidates' => [
+                        [
+                            'content' => [
+                                'parts' => [['text' => 'Hola!']],
+                            ],
+                        ],
+                    ],
+                ]);
+                return $response;
+            });
+
+        $result = $this->service->chat('Hola', []);
+
+        $this->assertTrue($result['success']);
+
+        $systemPrompt = $capturedContents[0]['parts'][0]['text'];
+        $this->assertStringNotContainsString('CONTEXTO DEL ESTUDIANTE', $systemPrompt);
+        $this->assertStringContainsString('ElectivoBot', $systemPrompt);
+    }
+
+    public function testChatWithEmptyEnrollmentsShowsNinguno(): void
+    {
+        $this->courseRepository
+            ->method('findActiveForContext')
+            ->willReturn([]);
+
+        $capturedContents = [];
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function ($method, $url, $options) use (&$capturedContents) {
+                $capturedContents = $options['json']['contents'] ?? [];
+                $response = $this->createMock(ResponseInterface::class);
+                $response->method('toArray')->willReturn([
+                    'candidates' => [
+                        [
+                            'content' => [
+                                'parts' => [['text' => 'Ok']],
+                            ],
+                        ],
+                    ],
+                ]);
+                return $response;
+            });
+
+        $studentContext = [
+            'name' => 'María López',
+            'grade' => '2A',
+            'interests' => [],
+            'enrolledCourses' => [],
+            'enrollmentOpen' => false,
+        ];
+
+        $result = $this->service->chat('Hola', [], $studentContext);
+
+        $systemPrompt = $capturedContents[0]['parts'][0]['text'];
+        $this->assertStringContainsString('Sin intereses registrados aún', $systemPrompt);
+        $this->assertStringContainsString('Ninguno', $systemPrompt);
+        $this->assertStringContainsString('Cerrado', $systemPrompt);
+    }
+
+    public function testChatWithEnrollmentClosedShowsCerrado(): void
+    {
+        $this->courseRepository
+            ->method('findActiveForContext')
+            ->willReturn([]);
+
+        $capturedContents = [];
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function ($method, $url, $options) use (&$capturedContents) {
+                $capturedContents = $options['json']['contents'] ?? [];
+                $response = $this->createMock(ResponseInterface::class);
+                $response->method('toArray')->willReturn([
+                    'candidates' => [
+                        [
+                            'content' => [
+                                'parts' => [['text' => 'Ok']],
+                            ],
+                        ],
+                    ],
+                ]);
+                return $response;
+            });
+
+        $studentContext = [
+            'name' => 'Carlos Ruiz',
+            'grade' => '4B',
+            'interests' => ['Ciencias' => 5],
+            'enrolledCourses' => [
+                ['id' => 2, 'name' => 'Biología Avanzada', 'category' => 'Ciencias'],
+            ],
+            'enrollmentOpen' => false,
+        ];
+
+        $result = $this->service->chat('Hola', [], $studentContext);
+
+        $systemPrompt = $capturedContents[0]['parts'][0]['text'];
+        $this->assertStringContainsString('Cerrado', $systemPrompt);
+    }
+
+    public function testSystemPromptContainsOffTopicRefusalRule(): void
+    {
+        $this->courseRepository
+            ->method('findActiveForContext')
+            ->willReturn([]);
+
+        $capturedContents = [];
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function ($method, $url, $options) use (&$capturedContents) {
+                $capturedContents = $options['json']['contents'] ?? [];
+                $response = $this->createMock(ResponseInterface::class);
+                $response->method('toArray')->willReturn([
+                    'candidates' => [
+                        [
+                            'content' => [
+                                'parts' => [['text' => 'Ok']],
+                            ],
+                        ],
+                    ],
+                ]);
+                return $response;
+            });
+
+        $result = $this->service->chat('Hola');
+
+        $systemPrompt = $capturedContents[0]['parts'][0]['text'];
+        $this->assertStringContainsString('temas no relacionados', $systemPrompt);
+        $this->assertStringContainsString('¡Ups!', $systemPrompt);
+        $this->assertStringContainsString('cursos electivos', $systemPrompt);
+    }
+
+    public function testChatIncludesHistoryInContents(): void
+    {
+        $this->courseRepository
+            ->method('findActiveForContext')
+            ->willReturn([]);
+
+        $capturedContents = [];
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function ($method, $url, $options) use (&$capturedContents) {
+                $capturedContents = $options['json']['contents'] ?? [];
+                $response = $this->createMock(ResponseInterface::class);
+                $response->method('toArray')->willReturn([
+                    'candidates' => [
+                        [
+                            'content' => [
+                                'parts' => [['text' => 'Respuesta']],
+                            ],
+                        ],
+                    ],
+                ]);
+                return $response;
+            });
+
+        $history = [
+            ['user' => 'Hola', 'bot' => '¡Hola! ¿En qué te puedo ayudar?'],
+            ['user' => '¿Qué cursos hay?', 'bot' => 'Tenemos varios cursos disponibles.'],
+        ];
+
+        $result = $this->service->chat('Quiero inscribirme', $history);
+
+        $this->assertTrue($result['success']);
+
+        // system prompt + 2 history turns (user+model each) + current message = 6
+        $this->assertCount(6, $capturedContents);
+        $this->assertEquals('user', $capturedContents[1]['role']);
+        $this->assertEquals('Hola', $capturedContents[1]['parts'][0]['text']);
+        $this->assertEquals('model', $capturedContents[2]['role']);
+        $this->assertEquals('¡Hola! ¿En qué te puedo ayudar?', $capturedContents[2]['parts'][0]['text']);
+    }
+
+    public function testChatWithStudentContextAndHistory(): void
+    {
+        $this->courseRepository
+            ->method('findActiveForContext')
+            ->willReturn([]);
+
+        $capturedContents = [];
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function ($method, $url, $options) use (&$capturedContents) {
+                $capturedContents = $options['json']['contents'] ?? [];
+                $response = $this->createMock(ResponseInterface::class);
+                $response->method('toArray')->willReturn([
+                    'candidates' => [
+                        [
+                            'content' => [
+                                'parts' => [['text' => 'Respuesta']],
+                            ],
+                        ],
+                    ],
+                ]);
+                return $response;
+            });
+
+        $history = [
+            ['user' => 'Hola', 'bot' => '¡Hola Juan!'],
+        ];
+
+        $studentContext = [
+            'name' => 'Juan Pérez',
+            'grade' => '3B',
+            'interests' => ['Filosofía' => 4],
+            'enrolledCourses' => [],
+            'enrollmentOpen' => true,
+        ];
+
+        $result = $this->service->chat('¿Qué más?', $history, $studentContext);
+
+        $this->assertTrue($result['success']);
+
+        // system prompt + 1 history turn (user+model) + current message = 4
+        $this->assertCount(4, $capturedContents);
+
+        // Verify student name in system prompt
+        $systemPrompt = $capturedContents[0]['parts'][0]['text'];
+        $this->assertStringContainsString('Juan Pérez', $systemPrompt);
+    }
+}

--- a/tests/Unit/Service/GeminiChatbotServiceTest.php
+++ b/tests/Unit/Service/GeminiChatbotServiceTest.php
@@ -6,6 +6,7 @@ use App\Entity\Course;
 use App\Entity\CourseCategory;
 use App\Entity\User;
 use App\Repository\CourseRepository;
+use App\Service\EnrollmentService;
 use App\Service\GeminiChatbotService;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -17,17 +18,20 @@ class GeminiChatbotServiceTest extends TestCase
     private GeminiChatbotService $service;
     private \PHPUnit\Framework\MockObject\MockObject $httpClient;
     private \PHPUnit\Framework\MockObject\MockObject $courseRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $enrollmentService;
     private \PHPUnit\Framework\MockObject\MockObject $logger;
 
     protected function setUp(): void
     {
         $this->httpClient = $this->createMock(HttpClientInterface::class);
         $this->courseRepository = $this->createMock(CourseRepository::class);
+        $this->enrollmentService = $this->createMock(EnrollmentService::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
         $this->service = new GeminiChatbotService(
             $this->httpClient,
             $this->courseRepository,
+            $this->enrollmentService,
             $this->logger,
             'test-api-key',
         );
@@ -134,6 +138,7 @@ class GeminiChatbotServiceTest extends TestCase
         $this->service = new GeminiChatbotService(
             $this->httpClient,
             $this->courseRepository,
+            $this->enrollmentService,
             $this->logger,
             'test-api-key',
         );

--- a/tests/Unit/Service/GeminiChatbotServiceToolCallTest.php
+++ b/tests/Unit/Service/GeminiChatbotServiceToolCallTest.php
@@ -1,0 +1,524 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\Course;
+use App\Entity\User;
+use App\Repository\CourseRepository;
+use App\Service\EnrollmentService;
+use App\Service\GeminiChatbotService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class GeminiChatbotServiceToolCallTest extends TestCase
+{
+    private GeminiChatbotService $service;
+    private \PHPUnit\Framework\MockObject\MockObject $httpClient;
+    private \PHPUnit\Framework\MockObject\MockObject $courseRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $enrollmentService;
+    private \PHPUnit\Framework\MockObject\MockObject $logger;
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createMock(HttpClientInterface::class);
+        $this->courseRepository = $this->createMock(CourseRepository::class);
+        $this->enrollmentService = $this->createMock(EnrollmentService::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->courseRepository
+            ->method('findActiveForContext')
+            ->willReturn([]);
+
+        $this->service = new GeminiChatbotService(
+            $this->httpClient,
+            $this->courseRepository,
+            $this->enrollmentService,
+            $this->logger,
+            'test-api-key',
+        );
+    }
+
+    private function createUser(int $id = 1, string $identifier = 'juan@test.com'): \PHPUnit\Framework\MockObject\MockObject
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn($id);
+        $user->method('getUserIdentifier')->willReturn($identifier);
+        return $user;
+    }
+
+    private function createCourse(
+        int $id = 1,
+        string $name = 'Filosofía Moderna',
+        int $maxCapacity = 25,
+        int $currentEnrollment = 18,
+        bool $isActive = true,
+    ): \PHPUnit\Framework\MockObject\MockObject {
+        $course = $this->createMock(Course::class);
+        $course->method('getId')->willReturn($id);
+        $course->method('getName')->willReturn($name);
+        $course->method('getMaxCapacity')->willReturn($maxCapacity);
+        $course->method('getCurrentEnrollment')->willReturn($currentEnrollment);
+        $course->method('isActive')->willReturn($isActive);
+        return $course;
+    }
+
+    private function createFunctionCallResponse(string $toolName, array $args): array
+    {
+        return [
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [
+                            ['functionCall' => ['name' => $toolName, 'args' => $args]],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function createTextResponse(string $text): array
+    {
+        return [
+            'candidates' => [
+                [
+                    'content' => [
+                        'parts' => [
+                            ['text' => $text],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function createMockResponse(array $data): \PHPUnit\Framework\MockObject\MockObject
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn($data);
+        return $response;
+    }
+
+    // --- Tool call loop tests ---
+
+    public function testSingleToolCallReturnsTextResponse(): void
+    {
+        $this->enrollmentService
+            ->method('getAvailableCourses')
+            ->with(category: null, search: null)
+            ->willReturn([
+                'courses' => [
+                    ['id' => 1, 'name' => 'Filosofía Moderna', 'category' => 'Filosofía', 'teacher' => 'Prof. García', 'schedule' => 'Lun 10:00', 'capacity' => '18/25', 'spots_available' => 7],
+                ],
+                'total' => 1,
+            ]);
+
+        $callCount = 0;
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function () use (&$callCount) {
+                $callCount++;
+                if ($callCount === 1) {
+                    return $this->createMockResponse($this->createFunctionCallResponse('get_available_courses', []));
+                }
+                return $this->createMockResponse($this->createTextResponse('Tenemos Filosofía Moderna disponible con 7 cupos.'));
+            });
+
+        $result = $this->service->chat('¿Qué cursos hay?');
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('Filosofía Moderna', $result['message']);
+        $this->assertEquals(2, $callCount);
+    }
+
+    public function testChainedToolCalls(): void
+    {
+        $this->enrollmentService
+            ->method('getAvailableCourses')
+            ->willReturn([
+                'courses' => [
+                    ['id' => 1, 'name' => 'Filosofía Moderna', 'category' => 'Filosofía', 'teacher' => 'Prof. García', 'schedule' => 'Lun 10:00', 'capacity' => '18/25', 'spots_available' => 7],
+                ],
+                'total' => 1,
+            ]);
+
+        $user = $this->createUser();
+
+        $this->enrollmentService
+            ->method('getCourseDetails')
+            ->with(courseId: 1, student: $user)
+            ->willReturn([
+                'id' => 1,
+                'name' => 'Filosofía Moderna',
+                'description' => 'Exploración filosófica',
+                'category' => 'Filosofía',
+                'teacher' => 'Prof. García',
+                'schedule' => 'Lun 10:00',
+                'capacity' => '18/25',
+                'spots_available' => 7,
+                'enrolled' => false,
+                'can_enroll' => true,
+                'enrollment_message' => '',
+            ]);
+
+        $callCount = 0;
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function () use (&$callCount) {
+                $callCount++;
+                if ($callCount === 1) {
+                    return $this->createMockResponse($this->createFunctionCallResponse('get_available_courses', []));
+                }
+                if ($callCount === 2) {
+                    return $this->createMockResponse($this->createFunctionCallResponse('get_course_details', ['course_id' => 1]));
+                }
+                return $this->createMockResponse($this->createTextResponse('Filosofía Moderna tiene 7 cupos disponibles.'));
+            });
+
+        $result = $this->service->chat('¿Qué cursos hay? Quiero ver detalles de Filosofía', [], [], $user);
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('7 cupos', $result['message']);
+        $this->assertEquals(3, $callCount);
+    }
+
+    public function testLoopCapReachedAtThreeIterations(): void
+    {
+        $this->enrollmentService
+            ->method('getAvailableCourses')
+            ->willReturn([
+                'courses' => [],
+                'total' => 0,
+            ]);
+
+        $this->logger
+            ->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('max iterations'));
+
+        $callCount = 0;
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function () use (&$callCount) {
+                $callCount++;
+                if ($callCount <= 3) {
+                    return $this->createMockResponse($this->createFunctionCallResponse('get_available_courses', []));
+                }
+                return $this->createMockResponse($this->createTextResponse('No hay cursos.'));
+            });
+
+        $result = $this->service->chat('Dame todos los cursos');
+
+        $this->assertTrue($result['success']);
+        $this->assertEquals(3, $callCount);
+    }
+
+    public function testToolCallErrorReturnsErrorToGemini(): void
+    {
+        $this->enrollmentService
+            ->method('getAvailableCourses')
+            ->willThrowException(new \RuntimeException('DB connection failed'));
+
+        $callCount = 0;
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function () use (&$callCount) {
+                $callCount++;
+                if ($callCount === 1) {
+                    return $this->createMockResponse($this->createFunctionCallResponse('get_available_courses', []));
+                }
+                return $this->createMockResponse($this->createTextResponse('Hubo un error al consultar cursos.'));
+            });
+
+        $result = $this->service->chat('¿Qué cursos hay?');
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('error', $result['message']);
+        $this->assertEquals(2, $callCount);
+    }
+
+    // --- executeTool routing tests ---
+
+    public function testGetAvailableCoursesForwardsFilters(): void
+    {
+        $this->enrollmentService
+            ->expects($this->once())
+            ->method('getAvailableCourses')
+            ->with(category: 'Filosofía', search: 'moderna')
+            ->willReturn(['courses' => [], 'total' => 0]);
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function () {
+                static $callCount = 0;
+                $callCount++;
+                if ($callCount === 1) {
+                    return $this->createMockResponse($this->createFunctionCallResponse(
+                        'get_available_courses',
+                        ['category' => 'Filosofía', 'search' => 'moderna']
+                    ));
+                }
+                return $this->createMockResponse($this->createTextResponse('No encontré cursos.'));
+            });
+
+        $result = $this->service->chat('Buscar cursos de filosofía moderna');
+
+        $this->assertTrue($result['success']);
+    }
+
+    public function testGetCourseDetailsRequiresUser(): void
+    {
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function () {
+                static $callCount = 0;
+                $callCount++;
+                if ($callCount === 1) {
+                    return $this->createMockResponse($this->createFunctionCallResponse(
+                        'get_course_details',
+                        ['course_id' => 1]
+                    ));
+                }
+                return $this->createMockResponse($this->createTextResponse('Necesito autenticación.'));
+            });
+
+        // No user passed — currentUser is null
+        $result = $this->service->chat('Detalles del curso 1');
+
+        $this->assertTrue($result['success']);
+    }
+
+    public function testEnrollInCourseReturnsPreviewOnly(): void
+    {
+        $user = $this->createUser();
+
+        $this->enrollmentService
+            ->expects($this->once())
+            ->method('getCourseDetails')
+            ->with(courseId: 1, student: $user)
+            ->willReturn([
+                'id' => 1,
+                'name' => 'Filosofía Moderna',
+                'spots_available' => 7,
+                'enrolled' => false,
+                'can_enroll' => true,
+                'enrollment_message' => '',
+            ]);
+
+        // enrollStudent should NOT be called — enroll_in_course is preview only
+        $this->enrollmentService
+            ->expects($this->never())
+            ->method('enrollStudent');
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function () {
+                static $callCount = 0;
+                $callCount++;
+                if ($callCount === 1) {
+                    return $this->createMockResponse($this->createFunctionCallResponse(
+                        'enroll_in_course',
+                        ['course_id' => 1]
+                    ));
+                }
+                return $this->createMockResponse($this->createTextResponse('¿Te inscribís en Filosofía Moderna?'));
+            });
+
+        $result = $this->service->chat('Quiero inscribirme en Filosofía Moderna', [], [], $user);
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('inscrib', $result['message']);
+    }
+
+    public function testConfirmEnrollmentActuallyEnrolls(): void
+    {
+        $user = $this->createUser();
+        $course = $this->createCourse();
+
+        $this->courseRepository
+            ->expects($this->atLeastOnce())
+            ->method('find')
+            ->with(1)
+            ->willReturn($course);
+
+        $this->enrollmentService
+            ->expects($this->once())
+            ->method('enrollStudent')
+            ->with($user, $course)
+            ->willReturn(['success' => true, 'message' => 'Inscripción exitosa.']);
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function () {
+                static $callCount = 0;
+                $callCount++;
+                if ($callCount === 1) {
+                    return $this->createMockResponse($this->createFunctionCallResponse(
+                        'confirm_enrollment',
+                        ['course_id' => 1]
+                    ));
+                }
+                return $this->createMockResponse($this->createTextResponse('¡Inscripción exitosa!'));
+            });
+
+        $result = $this->service->chat('Sí, quiero inscribirme', [], [], $user);
+
+        $this->assertTrue($result['success']);
+        $this->assertNotEmpty($result['message']);
+    }
+
+    public function testConfirmEnrollmentHandlesFailure(): void
+    {
+        $user = $this->createUser();
+        $course = $this->createCourse(currentEnrollment: 25, maxCapacity: 25);
+
+        $this->courseRepository
+            ->method('find')
+            ->with(1)
+            ->willReturn($course);
+
+        $this->enrollmentService
+            ->method('enrollStudent')
+            ->with($user, $course)
+            ->willReturn(['success' => false, 'message' => 'No hay cupo disponible.']);
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function () {
+                static $callCount = 0;
+                $callCount++;
+                if ($callCount === 1) {
+                    return $this->createMockResponse($this->createFunctionCallResponse(
+                        'confirm_enrollment',
+                        ['course_id' => 1]
+                    ));
+                }
+                return $this->createMockResponse($this->createTextResponse('No se pudo inscribir.'));
+            });
+
+        $result = $this->service->chat('Sí, inscribirme', [], [], $user);
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('No se pudo', $result['message']);
+    }
+
+    public function testConfirmEnrollmentCourseNotFound(): void
+    {
+        $user = $this->createUser();
+
+        $this->courseRepository
+            ->method('find')
+            ->with(999)
+            ->willReturn(null);
+
+        $this->enrollmentService
+            ->expects($this->never())
+            ->method('enrollStudent');
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function () {
+                static $callCount = 0;
+                $callCount++;
+                if ($callCount === 1) {
+                    return $this->createMockResponse($this->createFunctionCallResponse(
+                        'confirm_enrollment',
+                        ['course_id' => 999]
+                    ));
+                }
+                return $this->createMockResponse($this->createTextResponse('Curso no encontrado.'));
+            });
+
+        $result = $this->service->chat('Confirmar curso 999', [], [], $user);
+
+        $this->assertTrue($result['success']);
+    }
+
+    public function testUnknownToolReturnsError(): void
+    {
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function () {
+                static $callCount = 0;
+                $callCount++;
+                if ($callCount === 1) {
+                    return $this->createMockResponse($this->createFunctionCallResponse(
+                        'unknown_tool',
+                        []
+                    ));
+                }
+                return $this->createMockResponse($this->createTextResponse('No reconozco esa herramienta.'));
+            });
+
+        $result = $this->service->chat('Haz algo raro');
+
+        $this->assertTrue($result['success']);
+    }
+
+    // --- Tool declarations in request ---
+
+    public function testToolDeclarationsAreIncludedInRequest(): void
+    {
+        $capturedJson = null;
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function ($method, $url, $options) use (&$capturedJson) {
+                $capturedJson = $options['json'];
+                return $this->createMockResponse($this->createTextResponse('Hola'));
+            });
+
+        $this->service->chat('Hola');
+
+        $this->assertArrayHasKey('tools', $capturedJson);
+        $this->assertCount(4, $capturedJson['tools']);
+        $this->assertArrayHasKey('toolConfig', $capturedJson);
+
+        $toolNames = array_map(fn($t) => $t['name'], $capturedJson['tools']);
+        $this->assertContains('get_available_courses', $toolNames);
+        $this->assertContains('get_course_details', $toolNames);
+        $this->assertContains('enroll_in_course', $toolNames);
+        $this->assertContains('confirm_enrollment', $toolNames);
+    }
+
+    // --- Tool call appended to contents ---
+
+    public function testFunctionCallAndResponseAppendedToContents(): void
+    {
+        $this->enrollmentService
+            ->method('getAvailableCourses')
+            ->willReturn(['courses' => [], 'total' => 0]);
+
+        $capturedContents = [];
+
+        $this->httpClient
+            ->method('request')
+            ->willReturnCallback(function ($method, $url, $options) use (&$capturedContents) {
+                $capturedContents = $options['json']['contents'];
+                static $callCount = 0;
+                $callCount++;
+                if ($callCount === 1) {
+                    return $this->createMockResponse($this->createFunctionCallResponse('get_available_courses', []));
+                }
+                return $this->createMockResponse($this->createTextResponse('No hay cursos.'));
+            });
+
+        $this->service->chat('Dame cursos');
+
+        // After second call: system prompt + user msg + functionCall + functionResponse
+        $this->assertCount(4, $capturedContents);
+
+        // Verify functionCall in model message
+        $functionCallMsg = $capturedContents[2];
+        $this->assertEquals('model', $functionCallMsg['role']);
+        $this->assertArrayHasKey('functionCall', $functionCallMsg['parts'][0]);
+
+        // Verify functionResponse in user message
+        $functionResponseMsg = $capturedContents[3];
+        $this->assertEquals('user', $functionResponseMsg['role']);
+        $this->assertArrayHasKey('functionResponse', $functionResponseMsg['parts'][0]);
+        $this->assertEquals('get_available_courses', $functionResponseMsg['parts'][0]['functionResponse']['name']);
+    }
+}


### PR DESCRIPTION
Closes #18

## Summary
- Add student context injection to Gemini chatbot (name, grade, interests, enrolled courses)
- Implement Gemini function calling for course enrollment with confirmation flow
- Add off-topic refusal in Spanish with friendly suggestions

## Changes
| File | Change |
|------|--------|
| `src/Service/EnrollmentService.php` | Added getAvailableCourses(), getCourseDetails(), isEnrolled() methods |
| `src/Repository/CourseRepository.php` | Added findAvailableForStudent() query |
| `src/Controller/ChatbotController.php` | Added student context loading and 401 auth check |
| `src/Service/GeminiChatbotService.php` | Added tool declarations, tool_call loop, executeTool(), confirmation flow |
| `tests/Unit/Service/EnrollmentServiceTest.php` | 12 unit tests for new EnrollmentService methods |
| `tests/Unit/Service/GeminiChatbotServiceTest.php` | 11 unit tests for student context injection |
| `tests/Unit/Service/GeminiChatbotServiceToolCallTest.php` | 13 unit tests for tool_call loop |

## Test Plan
- [x] All 36 unit tests pass (149 assertions)
- [x] Tool call loop respects max 3 iterations
- [x] Confirmation flow returns preview before enrolling
- [x] Off-topic questions receive polite Spanish refusal
- [x] Edge cases handled: no spots, already enrolled, invalid course ID

## Contributor Checklist
- [x] Linked an approved issue (#18)
- [x] Added type:feature label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers